### PR TITLE
Create cucumber and rspec test for day of week displaying on dates

### DIFF
--- a/features/date_display.feature
+++ b/features/date_display.feature
@@ -1,0 +1,14 @@
+Feature: Display dates with day of the week
+  As a user of GatherEd
+  I want to see dates displayed with the day of the week in study group listings
+  So that I can better understand when study groups are scheduled
+
+  Background:
+    Given I am logged in as a student
+    And there is a course "COMP_SCI 110" with code "COMP_SCI_110"
+
+  Scenario: Study group dates include day of week in search results
+    Given there is a study group for "COMP_SCI 110" on "2025-12-15" at "8:10" with topic "Lecture Group Review"
+    When I go to the search page
+    And I select the course "COMP_SCI 110"
+    Then I should see "Monday, Dec 15, 2025" as part of the study group date

--- a/spec/views/study_groups/index_spec.rb
+++ b/spec/views/study_groups/index_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe "study_groups/index", type: :view do
+  let(:course) { create(:course, course_name: 'COMP_SCI 211', course_code: 'COMP_SCI_211') }
+  let(:creator) { create(:student) }
+  
+  it 'displays study group date with day of week when viewing course study groups' do
+    study_group = create(:study_group,
+      course: course,
+      creator: creator,
+      topic: 'Lab session',
+      start_time: Time.zone.parse('2025-11-23 00:38'),
+      end_time: Time.zone.parse('2025-11-23 02:38')
+    )
+    
+    assign(:study_groups, [study_group])
+    assign(:course, course)
+    
+    render
+    
+    expect(rendered).to match(/Sunday.*Nov 23, 2025/)
+  end
+
+  it 'displays day of week for study groups on different days' do
+    study_group = create(:study_group,
+      course: course,
+      creator: creator,
+      topic: 'Final Exam Prep',
+      start_time: Time.zone.parse('2025-12-08 14:00'),
+      end_time: Time.zone.parse('2025-12-08 16:00')
+    )
+    
+    assign(:study_groups, [study_group])
+    assign(:course, course)
+    
+    render
+    
+    expect(rendered).to match(/Monday.*Dec 8, 2025/)
+  end
+end


### PR DESCRIPTION
- Cucumber test that makes sure at least group cards on the search page have the day of the week along with the dates on the class card, along with rspec tests